### PR TITLE
Catch uglify error

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,16 @@ module.exports = function browserifySize (name, options, callback) {
     if (err) return callback(err)
     bundle(dir, function (err, code) {
       if (err) return callback(err)
-      code = minify(code)
-      gzipSize(code, callback)
+      
+      minify(code, function(error, minifiedCode){
+        if(error === null){
+          gzipSize(minifiedCode, callback)
+        }
+        else {
+          return callback(error);
+        }
+      })
+      
     })
   })
 }
@@ -25,6 +33,12 @@ function bundle (dir, callback) {
   browserify(dir).bundle(callback)
 }
 
-function minify (code) {
-  return uglify.minify(code.toString(), {fromString: true}).code
+function minify (code, callback) {
+  try {
+    var minifiedCode = uglify.minify(code.toString(), {fromString: true}).code
+    callback(null, minifiedCode)
+  }
+  catch(error) {
+    callback(error)
+  }
 }

--- a/index.js
+++ b/index.js
@@ -15,16 +15,14 @@ module.exports = function browserifySize (name, options, callback) {
     if (err) return callback(err)
     bundle(dir, function (err, code) {
       if (err) return callback(err)
-      
-      minify(code, function(error, minifiedCode){
-        if(error === null){
+      minify(code, function (error, minifiedCode) {
+        if (error === null) {
           gzipSize(minifiedCode, callback)
-        }
-        else {
-          return callback(error);
+        } else {
+          return callback(error)
         }
       })
-      
+
     })
   })
 }
@@ -37,8 +35,7 @@ function minify (code, callback) {
   try {
     var minifiedCode = uglify.minify(code.toString(), {fromString: true}).code
     callback(null, minifiedCode)
-  }
-  catch(error) {
+  } catch(error) {
     callback(error)
   }
 }

--- a/test.js
+++ b/test.js
@@ -22,3 +22,10 @@ test('remote', function (t) {
     t.ok(bytes < 500)
   })
 })
+
+test('uglify error should not crash the application', function (t) {
+  t.doesNotThrow(function () {
+    size('qs', {version: '6.0.1'}, function () {})
+  })
+  t.end()
+})


### PR DESCRIPTION
There are packages e.g. qs version 6.0.1 which crash the application because of uncaught uglify error.
